### PR TITLE
fix: Remove {version} inside download link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ NAVER Cloud Platform Official Guide provides more detailed and friendly guides.
 2. Download the `ncp-iam-authenticator` binary.
     - macOS, Linux
     ```bash
-    curl -o ncp-iam-authenticator -L https://github.com/NaverCloudPlatform/ncp-iam-authenticator/releases/download/v${version}/ncp-iam-authenticator_${version}_${os}_${arch}
+    curl -o ncp-iam-authenticator -L https://github.com/NaverCloudPlatform/ncp-iam-authenticator/releases/download/v${version}/ncp-iam-authenticator_${os}_${arch}
     ```
     - windows (PowerShell)
     ```bash
-    curl -o ncp-iam-authenticator -L https://github.com/NaverCloudPlatform/ncp-iam-authenticator/releases/download/v${version}/ncp-iam-authenticator_${version}_windows_amd64.exe
+    curl -o ncp-iam-authenticator -L https://github.com/NaverCloudPlatform/ncp-iam-authenticator/releases/download/v${version}/ncp-iam-authenticator_windows_amd64.exe
     ```
 3. (Optional) You can use SHA-256 SUM to check the downloaded binary file.
     1. Check the sum of SHA-256 of the `ncp-iam-authenticator` binary file.


### PR DESCRIPTION
깃 릴리즈 경로와 리드미에서 제시된 예시 경로가 일치하지 않아 변경 제안드립니다.

현재 깃 릴리즈에서 생성되는 파일 경로는
`https://github.com/NaverCloudPlatform/ncp-iam-authenticator/releases/download/v1.1.1/ncp-iam-authenticator_linux_amd64` 입니다.

그러나 변경 전 리드미에서는 이를 
`ncp-iam-authenticator_${version}_${os}_${arch}` 로 표현하고 있으므로 일치하지 않습니다.

제가 제안드린대로 변경되면 정상적으로 설치됨을 확인했습니다.